### PR TITLE
set TermEncoding to latin1; use user's preferred help browser

### DIFF
--- a/lib/window.g
+++ b/lib/window.g
@@ -427,7 +427,4 @@ if IsBound(SetUserPreference) then
     SetUserPreference("Browse", "SelectPackageName", false);
 fi;
 
-GAPInfo.TermEncoding := "ASCII";
-
-SetHelpViewer("firefox");
-
+GAPInfo.TermEncoding := "latin1";


### PR DESCRIPTION
There is a serious bug with GAPInfo.TermEncoding := "ASCII".  Basic printing fails under this setting.  The right fix is to make this work in GAPDoc, and Frank Lübeck is aware of the problem.  Meanwhile, setting the TermEncoding to latin1 works around the problem, and is unlikely to cause new problems.

I also removed the SetHelpViewer("firefox") command.  A user of xgap may not even have Firefox installed, and this is something that should be set in GAP preferences, anyway.  

It would perhaps be better style to split this two-line fix into two one-line fixes, but the changes are so small that it doesn't seem to make much difference.