### PR TITLE
Add missing escapes to buildman.pe.

### DIFF
--- a/doc/buildman.pe
+++ b/doc/buildman.pe
@@ -578,7 +578,7 @@ sub make_tex {
 
       SCANMSK: while ( $line = <MSK> ) {
             # treat the {{...}} replacements
-            while ( $line =~ /{{([^}]*)}}/ ) {
+            while ( $line =~ /\{\{([^}]*)\}\}/ ) {
                 $key = $1;
                 if ( $key =~ /date/ ) {
                     $replace=`date +"%d %B %Y"`;


### PR DESCRIPTION
Perl 5.28.1, at least, complains about missing escape characters in buildman.pe.  This change escapes curly braces as needed to satisfy perl.