### PR TITLE
Enlarge the 'c' array in StartGapProcess to prevent overruns.

### DIFF
--- a/src.x11/pty.c
+++ b/src.x11/pty.c
@@ -1295,7 +1295,7 @@ int StartGapProcess ( name, argv )
     String          argv[];
 {
     Int             j;       /* loop variables                  */
-    char            c[8];    /* buffer for communication        */
+    char            c[10];   /* buffer for communication        */
     int             master;  /* pipe to GAP                     */
     int             n;       /* return value of 'select'        */
     int             slave;   /* pipe from GAP                   */


### PR DESCRIPTION
On line 1420 of pty.c, we see that the while loop can continue until j == 10.  Therefore, after the loop, the access to c[j-1] on line 1456 can access as high as index 9.  This may be unlikely, but to be completely safe, we need to ensure that the c array has size at least 10.