### PR TITLE
doc: Fix reference to IdGroup

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -18,8 +18,8 @@
 %%
 \BeginningOfBook{xgap}
 \UseReferences{../../../doc/tut}
-\UseReferences{../../../doc/prg}
 \UseReferences{../../../doc/ref}
+\UseReferences{../../smallgrp/doc}
 %
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/doc/sglatsys.tex
+++ b/doc/sglatsys.tex
@@ -640,7 +640,7 @@ reference manual.
 \>`Isomorphism'{Isomorphism}@{`Isomorphism'}
 
 computes and displays  the isomorphism type of  $u$.  This will only work
-if the size of $u$ is small.  See "ref:IdGroup"  in the {\GAP}
+if the size of $u$ is small.  See "smallgrp:IdGroup"  in the smallgrp
 reference manual for details.
 
 \bigskip%


### PR DESCRIPTION
Also remove an unused reference to a `prg` manual.  With this change, the documentation building step still complains about 1 broken reference, `ref:Centralizer` on line 432 of `doc/sglatsys.tex`.  I don't know what that should refer to.
