### PR TITLE
Fix out-of-bounds read & write

### DIFF
--- a/src.x11/selfile.c
+++ b/src.x11/selfile.c
@@ -1243,14 +1243,19 @@ static void SFsetText(char *path)
 static void
 SFreplaceText(SFDir *dir, char *str)
 {
-	int	len;
+	size_t len;
 
 	*(dir->path) = 0;
 	len = strlen(str);
-	if (str[len - 1] == '/') {
-		(void) strcat(SFcurrentPath, str);
+	if (len == 0) {
+	} else if (str[len - 1] == '/') {
+		snprintf(SFcurrentPath + strlen(SFcurrentPath),
+			sizeof(SFcurrentPath) - strlen(SFcurrentPath),
+			"%s", str);
 	} else {
-		(void) strncat(SFcurrentPath, str, len - 1);
+		snprintf(SFcurrentPath + strlen(SFcurrentPath),
+			sizeof(SFcurrentPath) - strlen(SFcurrentPath),
+			"%.*s", (int)(len - 1), str);
 	}
 	if (strncmp(SFcurrentPath, SFstartDir, strlen(SFstartDir))) {
 		SFsetText(SFcurrentPath);


### PR DESCRIPTION
gcc warns:

```
selfile.c:1253:24: warning: "strncat" specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1253 |                 (void) strncat(SFcurrentPath, str, len - 1);
```

The third argument ought to be the size of the _destination_, not the _source_. You need snprintf (or a contrived mix of min()+max()) if you want to also restrict the source length.

Also, `len - 1` can underflow if the string length for some reason is 0, catch that case as well.

Run through the compiler only; not runtime-tested.