### PR TITLE
Adapt to C23, the default C standard in GCC 15

### DIFF
--- a/src.x11/gaptext.c
+++ b/src.x11/gaptext.c
@@ -14,11 +14,11 @@
 #include    "utils.h"
 #include    "gaptext.h"
 
-extern void _XawTextPrepareToUpdate();
-extern int  _XawTextReplace();
-extern void _XawTextSetScrollBars();
-extern void _XawTextCheckResize();
-extern void _XawTextExecuteUpdate();
+extern void _XawTextPrepareToUpdate(TextWidget);
+extern int  _XawTextReplace(TextWidget, XawTextPosition, XawTextPosition, XawTextBlock *);
+extern void _XawTextSetScrollBars(TextWidget);
+extern void _XawTextCheckResize(TextWidget);
+extern void _XawTextExecuteUpdate(TextWidget);
 
 
 /****************************************************************************
@@ -666,7 +666,7 @@ static XawTextPosition GapSrcReadText (
     Widget              w,
     XawTextPosition     pos,
     XawTextBlock      * text,
-    unsigned long       length )
+    Int                 length )
 {
     GapSrcObject        src = (GapSrcObject) w;
 
@@ -913,9 +913,9 @@ GapSrcClassRec gapSrcClassRec =
     /* extension                */      NULL
   },
   { /* textSrc_class fields     */
-    /* Read                     */      (XawTextPosition (*)())GapSrcReadText,
-    /* Replace                  */      (int (*)()) GapSrcReplaceText,
-    /* Scan                     */      (XawTextPosition (*)()) GapSrcScan,
+    /* Read                     */      GapSrcReadText,
+    /* Replace                  */      GapSrcReplaceText,
+    /* Scan                     */      GapSrcScan,
     /* Search                   */      XtInheritSearch,
     /* SetSelection             */      XtInheritSetSelection,
     /* ConvertSelection         */      XtInheritConvertSelection
@@ -1006,7 +1006,7 @@ void GTDelete ( Widget w, XawTextScanDirection dir, XawTextScanType type )
     Int                     from;
 
     /* prepare text for update */
-    _XawTextPrepareToUpdate(gap);
+    _XawTextPrepareToUpdate((TextWidget)gap);
     gap->text.time = CurrentTime;
 
     /* find <to> and <from> */
@@ -1025,19 +1025,19 @@ void GTDelete ( Widget w, XawTextScanDirection dir, XawTextScanType type )
     /* remove text */
     text.length = 0;
     text.firstPos = 0;
-    if ( _XawTextReplace( gap, from, to, &text ) )
+    if ( _XawTextReplace( (TextWidget)gap, from, to, &text ) )
     {
 	XBell(XtDisplay(gap), 50);
 	goto error;
     }
     gap->text.insertPos = from;
     gap->text.showposition = TRUE;
-    _XawTextSetScrollBars(gap);
+    _XawTextSetScrollBars((TextWidget)gap);
 
     /* do update */
 error:
-    _XawTextCheckResize(gap);
-    _XawTextExecuteUpdate(gap);
+    _XawTextCheckResize((TextWidget)gap);
+    _XawTextExecuteUpdate((TextWidget)gap);
     gap->text.mult = 1;
 }
 

--- a/src.x11/gaptext.h
+++ b/src.x11/gaptext.h
@@ -96,10 +96,10 @@ extern GapTextClassRec gapTextClassRec;
 typedef struct
 {
     /* function to call when receiving input */
-    void 		(*input_callback)();
+    void 		(*input_callback)(String, Int);
 
     /* function to position caret */
-    Int 		(*check_caret_pos)();
+    Int 		(*check_caret_pos)(Int, Int);
 
     /* input buffer for unprocessed input */
     String              buffer;

--- a/src.x11/popdial.c
+++ b/src.x11/popdial.c
@@ -71,10 +71,10 @@ static struct { String name;  Int flag; } buttons[] =
     { "overwrite",  PD_OVERWRITE }
 };
 
-static void ButtonSelected ( w, cld, cd )
-    Widget	    w;
-    XtPointer       cld;
-    XtPointer       cd;
+static void ButtonSelected (
+    Widget          w,
+    XtPointer       cld,
+    XtPointer       cd)
 {
     Int             i;
     Int           * res = (int*) cld;
@@ -96,13 +96,13 @@ static void ButtonSelected ( w, cld, cd )
 
 static Boolean BrokenWM = False;
 
-TypePopupDialog CreatePopupDialog ( app, top, name, bt, def, pix )
-    XtAppContext        app;
-    Widget	        top;
-    String              name;
-    Int                 bt;
-    Int                 def;
-    Pixmap              pix;
+TypePopupDialog CreatePopupDialog (
+    XtAppContext        app,
+    Widget              top,
+    String              name,
+    Int                 bt,
+    Int                 def,
+    Pixmap              pix)
 {
     Display           * dp;
     TypePopupDialog     dialog;
@@ -198,11 +198,11 @@ void PopupDialogBrokenWM ( )
 */
 static Cursor BlobCursor = 0;
 
-Int PopupDialog ( dialog, message, deflt, result )
-    TypePopupDialog	dialog;
-    String              message;
-    String              deflt;
-    String *            result;
+Int PopupDialog (
+    TypePopupDialog     dialog,
+    String              message,
+    String              deflt,
+    String *            result)
 {
     Display *           display;
     Position            x1,  y1,  tmp;

--- a/src.x11/pty.c
+++ b/src.x11/pty.c
@@ -117,11 +117,11 @@ Boolean ExecRunning = False;
 */
 #ifdef DEBUG_ON
 
-Int READ_GAP ( file, where, line, len )
-    String	file;
-    Int         where;
-    String      line;
-    Int         len;
+Int READ_GAP (
+    String      file,
+    Int         where,
+    String      line,
+    Int         len)
 {
     Int         n;
     Int         old;
@@ -171,9 +171,9 @@ Int READ_GAP ( file, where, line, len )
 
 #else
 
-Int ReadGap ( line, len )
-    String	line;
-    Int         len;
+Int ReadGap (
+    String      line,
+    Int         len)
 {
     Int         n;
     Int         old;
@@ -201,15 +201,15 @@ Int ReadGap ( line, len )
 **
 *F  WriteGap( <line>, <len> ) . . . . . . . . . . . . . . . . write gap input
 */
-extern int errno;
+#include <errno.h>
 
 #ifdef DEBUG_ON
 
-void WRITE_GAP ( file, where, line, len )
-    String	file;
-    Int		where;
-    String	line;
-    Int		len;
+void WRITE_GAP (
+    String      file,
+    Int         where,
+    String      line,
+    Int         len)
 {
     Int         res;
 
@@ -238,9 +238,9 @@ void WRITE_GAP ( file, where, line, len )
 
 #else
 
-void WriteGap ( line, len )
-    String	line;
-    Int         len;
+void WriteGap (
+    String      line,
+    Int         len)
 {
     Int         res;
 
@@ -337,8 +337,8 @@ static Int LastLine;
 
 *F  WaitInput( <buf> )  . . . . . . . . . . . . . . .  wait for one character
 */
-void WaitInput ( buf )
-    struct _in_buf    * buf;
+void WaitInput (
+    struct _in_buf    * buf)
 {
     Int                 len;
 
@@ -356,8 +356,8 @@ void WaitInput ( buf )
 **
 *F  WaitInput2( <buf> ) . . . . . . . . . . . . . . . wait for two characters
 */
-void WaitInput2 ( buf )
-    struct _in_buf    * buf;
+void WaitInput2 (
+    struct _in_buf    * buf)
 {
     Int                 len;
 
@@ -385,8 +385,8 @@ void WaitInput2 ( buf )
 **
 *F  ReadLine( <buf> ) . . . . . . . . . . . . . . . . . . . . . . read a line
 */
-void ReadLine ( buf )
-    struct _in_buf    * buf;
+void ReadLine (
+    struct _in_buf    * buf)
 {
     String              ptr = GapBuffer;
 
@@ -435,9 +435,9 @@ static struct _storage
 }
 Storage = { 0, 0, 0 };
 
-void StoreInput ( str, len )
-    String      str;
-    Int         len;
+void StoreInput (
+    String      str,
+    Int         len)
 {
     if ( Storage.buffer == 0 )
     {
@@ -460,8 +460,8 @@ void StoreInput ( str, len )
 */
 static Char InputCookie = 'A';
 
-void ProcessStoredInput ( state )
-    Int             state;
+void ProcessStoredInput (
+    Int             state)
 {
     String          ptr;
     String          free;
@@ -558,8 +558,8 @@ again:
 **
 *F  SimulateInput( <str> )  . . . . . . . . . .  enter a line as command line
 */
-void SimulateInput ( str )
-    String  str;
+void SimulateInput (
+    String  str)
 {
     Int     pos;
 
@@ -585,8 +585,8 @@ void SimulateInput ( str )
 Boolean PlayingBack = False;
 FILE * Playback = 0;
 
-int PlaybackFile ( str )
-    String      str;
+int PlaybackFile (
+    String      str)
 {
     if ( Playback != 0 ) {
 	fclose(Playback);
@@ -609,9 +609,9 @@ int ResumePlayback ( void )
     return True;
 }
 
-void KeyboardInput ( str, len )
-    String      str;
-    Int     	len;
+void KeyboardInput (
+    String      str,
+    Int         len)
 {
     char        buf[1025];
 
@@ -750,9 +750,9 @@ void KeyboardInput ( str, len )
 **
 *F  CheckCaretPos( <new>, <old> ) . . . . . . . . . . .  check caret movement
 */
-Int CheckCaretPos ( new, old )
-    Int     new;
-    Int     old;
+Int CheckCaretPos (
+    Int     new,
+    Int     old)
 {
     /* if <LastLine> is -1,  then gap is running,  ignore move */
     if ( LastLine < 0 )
@@ -824,10 +824,10 @@ static Boolean ParseInt (
 
 static char TBuf[SIZE_BUFFER];
 
-void GapOutput ( cld, fid, id )
-    XtPointer       cld;
-    int           * fid;
-    XtInputId       id;
+void GapOutput (
+    XtPointer       cld,
+    int           * fid,
+    XtInputId       id)
 {
     char            ch;
     Int             special;
@@ -1272,7 +1272,7 @@ static UInt OpenPty(int * master, int * slave)
 **
 *F  StartGapProcess( <name>, <argv> ) . . . start a gap subprocess using ptys
 */
-static void GapStatusHasChanged ()
+static void GapStatusHasChanged (int signo)
 {
     int             w;
 
@@ -1286,9 +1286,9 @@ static void GapStatusHasChanged ()
     exit(1);
 }
 
-int StartGapProcess ( name, argv )
-    String          name;
-    String          argv[];
+int StartGapProcess (
+    String          name,
+    String          argv[])
 {
     Int             j;       /* loop variables                  */
     char            c[10];   /* buffer for communication        */

--- a/src.x11/selfile.c
+++ b/src.x11/selfile.c
@@ -110,33 +110,30 @@ typedef struct {
 	time_t	mtime;
 } SFDir;
 
-static void
-	SFenterList(),
-	SFleaveList(),
-	SFmotionList(),
-	SFbuttonPressList(),
-	SFbuttonReleaseList();
+static void SFenterList(Widget, long, XEnterWindowEvent *);
+static void SFleaveList(Widget, int, XEvent *);
+static void SFmotionList(Widget, int, XMotionEvent *);
+static void SFbuttonPressList(Widget, int, XButtonPressedEvent *);
+static void SFbuttonReleaseList(Widget, int, XButtonReleasedEvent *);
 
-static void
-	SFvSliderMovedCallback(),
-	SFvFloatSliderMovedCallback(),
-	SFhSliderMovedCallback(),
-	SFpathSliderMovedCallback(),
-	SFvAreaSelectedCallback(),
-	SFhAreaSelectedCallback(),
-	SFpathAreaSelectedCallback();
+static void SFvSliderMovedCallback(Widget, long, int);
+static void SFvFloatSliderMovedCallback(Widget, int, float *);
+static void SFhSliderMovedCallback(Widget, int, float *);
+static void SFpathSliderMovedCallback(Widget, XtPointer, float *);
+static void SFvAreaSelectedCallback(Widget, int, int);
+static void SFhAreaSelectedCallback(Widget, int, int);
+static void SFpathAreaSelectedCallback(Widget, XtPointer, int);
 
-static Boolean SFworkProc();
+static Boolean SFworkProc(XtPointer);
 
-static int SFcompareEntries();
+static int SFcompareEntries(const void *, const void *);
 
-static void SFdirModTimer();
+static void SFdirModTimer(XtPointer, XtIntervalId *);
 
-static char SFstatChar();
+static char SFstatChar(struct stat *);
 
 
-/* BSD 4.3 errno.h does not declare errno */
-extern int errno;
+#include <errno.h>
 /* extern int sys_nerr; */
 
 #if !defined(S_ISDIR) && defined(S_IFDIR)
@@ -1157,7 +1154,7 @@ SFpathAreaSelectedCallback(Widget w, XtPointer client_data, int pnew)
 }
 
 static Boolean
-SFworkProc()
+SFworkProc(XtPointer closure)
 {
 	register SFDir		*dir;
 	register SFEntry	*entry;

--- a/src.x11/utils.c
+++ b/src.x11/utils.c
@@ -62,13 +62,13 @@ Int Debug = 0;
 *F  List( <len> )   . . . . . . . . . . . . . . . . . . .   create a new list
 */
 #ifdef DEBUG_ON
-TypeList LIST ( file, line, len )
-    String	file;
-    Int         line;
-    UInt        len;
+TypeList LIST (
+    String      file,
+    Int         line,
+    UInt        len)
 #else
-TypeList List ( len )
-    UInt        len;
+TypeList List (
+    UInt        len)
 #endif
 {
     TypeList    list;
@@ -95,15 +95,15 @@ TypeList List ( len )
 *F  AddList( <lst>, <elm> ) . . . . . . . .  add list element <elm> to <list>
 */
 #ifdef DEBUG_ON
-void ADD_LIST ( file, line, lst, elm )
-    String	file;
-    Int         line;
-    TypeList    lst;
-    Pointer     elm;
+void ADD_LIST (
+    String      file,
+    Int         line,
+    TypeList    lst,
+    Pointer     elm)
 #else
-void AddList ( lst, elm )
-    TypeList    lst;
-    Pointer     elm;
+void AddList (
+    TypeList    lst,
+    Pointer     elm)
 #endif
 {
     /* give some debug information */

--- a/src.x11/xcmds.c
+++ b/src.x11/xcmds.c
@@ -2056,8 +2056,8 @@ void InitXCMDS ()
 **
 *F  UpdateXCMDS( <state> )  . . . . . . . . . .  gap is/isn't accepting input
 */
-void UpdateXCMDS ( state )
-    Boolean             state;
+void UpdateXCMDS (
+    Boolean             state)
 {
     TypeGapWindow *	win;
     Int                 i;

--- a/src.x11/xcmds.h
+++ b/src.x11/xcmds.h
@@ -129,7 +129,7 @@ TypePaneData;
 */
 extern void     InitXCMDS( void );
 extern void     ExitXMCDS( void );
-extern void     UpdateXCMDS( Int );
+extern void     UpdateXCMDS( Boolean );
 extern Boolean  GapWindowCmd( String, Int );
 
 #endif

--- a/src.x11/xgap.c
+++ b/src.x11/xgap.c
@@ -255,8 +255,15 @@ static char *FallbackResources[] =
 *V  GapMenu . . . . . . . . . . . . . . . . . . . . . . . . xgap's "GAP" menu
 **
 */
-static void MenuQuitGap ()   { KeyboardInput( "@C@A@Kquit;\nquit;\n", 18 ); }
-static void MenuKillGap ()   { KillGap();                                   }
+static void MenuQuitGap (TypeMenuItem *item)
+{
+    KeyboardInput( "@C@A@Kquit;\nquit;\n", 18 );
+}
+
+static void MenuKillGap (TypeMenuItem *item)
+{
+    KillGap();
+}
 
 #ifdef DEBUG_ON
 static void MenuResyncGap ()
@@ -269,8 +276,8 @@ static void MenuResyncGap ()
 }
 #endif
 
-static void MenuPastePrompt ( item )
-    TypeMenuItem *      item;
+static void MenuPastePrompt (
+    TypeMenuItem *      item)
 {
     static Boolean	paste = False;
 
@@ -284,8 +291,8 @@ static void MenuPastePrompt ( item )
                        (String)NULL );
 }
 
-static void MenuQuitGapCTRD ( item )
-    TypeMenuItem *      item;
+static void MenuQuitGapCTRD (
+    TypeMenuItem *      item)
 {
     QuitGapCtrlD = !QuitGapCtrlD;
     if ( QuitGapCtrlD )
@@ -297,8 +304,8 @@ static void MenuQuitGapCTRD ( item )
 }
 
 #ifndef NO_FILE_SELECTOR
-void MenuReadFile ( item )
-    TypeMenuItem *	item;
+void MenuReadFile (
+    TypeMenuItem *	item)
 {
     Int			res;
     String              str;
@@ -341,14 +348,14 @@ static TypeMenuItem GapMenu[] =
 *V  HelpMenu  . . . . . . . . . . . . . . . . . . . . . .  xgap's "Help" menu
 **
 */
-static void MenuChapters ()     { SimulateInput( "?Chapters\n" ); }
-static void MenuSections ()     { SimulateInput( "?Sections\n" ); }
-static void MenuCopyright ()    { SimulateInput( "?Copyright\n" );}
-static void MenuHelp ()         { SimulateInput( "?Help\n" );     }
-static void MenuNextHelp ()     { SimulateInput( "?>\n" );        }
-static void MenuNextChapter ()  { SimulateInput( "?>>\n" );       }
-static void MenuPrevChapter ()  { SimulateInput( "?<<\n" );       }
-static void MenuPrevHelp ()     { SimulateInput( "?<\n" );        }
+static void MenuChapters (TypeMenuItem *item)     { SimulateInput( "?Chapters\n" ); }
+static void MenuSections (TypeMenuItem *item)     { SimulateInput( "?Sections\n" ); }
+static void MenuCopyright (TypeMenuItem *item)    { SimulateInput( "?Copyright\n" );}
+static void MenuHelp (TypeMenuItem *item)         { SimulateInput( "?Help\n" );     }
+static void MenuNextHelp (TypeMenuItem *item)     { SimulateInput( "?>\n" );        }
+static void MenuNextChapter (TypeMenuItem *item)  { SimulateInput( "?>>\n" );       }
+static void MenuPrevChapter (TypeMenuItem *item)  { SimulateInput( "?<<\n" );       }
+static void MenuPrevHelp (TypeMenuItem *item)     { SimulateInput( "?<\n" );        }
 
 
 static TypeMenuItem HelpMenu[] =
@@ -372,11 +379,11 @@ static TypeMenuItem HelpMenu[] =
 *V  RunMenu . . . . . . . . . . . . . . . . . . . . . . . . xgap's "Run" menu
 **
 */
-static void MenuInterrupt () { InterruptGap();                            }
-static void MenuQuitBreak () { SimulateInput( "quit;\n" );                }
-static void MenuContBreak () { SimulateInput( "return;\n" );              }
-static void MenuGarbColl ()  { SimulateInput( "GASMAN(\"collect\");\n" ); }
-static void MenuGarbMesg ()  { SimulateInput( "GASMAN(\"message\");\n" ); }
+static void MenuInterrupt (TypeMenuItem *item) { InterruptGap();                            }
+static void MenuQuitBreak (TypeMenuItem *item) { SimulateInput( "quit;\n" );                }
+static void MenuContBreak (TypeMenuItem *item) { SimulateInput( "return;\n" );              }
+static void MenuGarbColl (TypeMenuItem *item)  { SimulateInput( "GASMAN(\"collect\");\n" ); }
+static void MenuGarbMesg (TypeMenuItem *item)  { SimulateInput( "GASMAN(\"message\");\n" ); }
 
 static TypeMenuItem RunMenu[] =
 {
@@ -497,8 +504,8 @@ static void MenuSelected (
 **
 *F  UpdateMenus( <state> )  . . . . . .  update menus in case of state change
 */
-void UpdateMenus ( state )
-    Int         state;
+void UpdateMenus (
+    Int         state)
 {
     TypeList	l;
     Int         i;
@@ -581,9 +588,9 @@ static Widget LabelLiveObjects;
 static Widget LabelLiveKB;
 static Widget LabelTotalKBytes;
 
-void UpdateMemoryInfo ( type, val )
-    Int		type;
-    Int         val;
+void UpdateMemoryInfo (
+    Int         type,
+    Int         val)
 {
     char        tmp[30];
 
@@ -806,11 +813,11 @@ static void CreateGapWindow ( void )
 
 *F  MyErrorHandler(<dis>) . . . . . . . . . . . . kill gap in case of X error
 */
-static int (*OldErrorHandler)();
+static int (*OldErrorHandler)(Display *, XErrorEvent *);
 
-static int MyErrorHandler ( dis, evt )
-    Display       * dis;
-    XErrorEvent	    evt;
+static int MyErrorHandler (
+    Display       * dis,
+    XErrorEvent   * evt)
 {
 #   ifdef DEBUG_ON
         fputs( "killing gap because of X error\n", stderr );
@@ -824,10 +831,10 @@ static int MyErrorHandler ( dis, evt )
 **
 *F  MyIOErrorHandler(<dis>) . . . . . . . . . . . kill gap in case of X error
 */
-static int (*OldIOErrorHandler)();
+static int (*OldIOErrorHandler)(Display *);
 
-static int MyIOErrorHandler ( dis )
-    Display   * dis;
+static int MyIOErrorHandler (
+    Display   * dis)
 {
 #   ifdef DEBUG_ON
         fputs( "killing gap because of X IO error\n", stderr );
@@ -843,68 +850,68 @@ static int MyIOErrorHandler ( dis )
 */
 #ifdef DEBUG_ON
 
-static void (*OldSignalHandlerHUP)();
-static void (*OldSignalHandlerINT)();
-static void (*OldSignalHandlerQUIT)();
-static void (*OldSignalHandlerILL)();
-static void (*OldSignalHandlerIOT)();
-static void (*OldSignalHandlerBUS)();
-static void (*OldSignalHandlerSEGV)();
+static void (*OldSignalHandlerHUP)(int);
+static void (*OldSignalHandlerINT)(int);
+static void (*OldSignalHandlerQUIT)(int);
+static void (*OldSignalHandlerILL)(int);
+static void (*OldSignalHandlerIOT)(int);
+static void (*OldSignalHandlerBUS)(int);
+static void (*OldSignalHandlerSEGV)(int);
 
-static void MySignalHandlerHUP ()
+static void MySignalHandlerHUP (int signo)
 {
     fputs( "killing gap because of signal HUP\n", stderr );
     KillGap();
-    OldSignalHandlerHUP();
+    OldSignalHandlerHUP(signo);
     exit(1);
 }
-static void MySignalHandlerINT ()
+static void MySignalHandlerINT (int signo)
 {
     fputs( "killing gap because of signal INT\n", stderr );
     KillGap();
-    OldSignalHandlerINT();
+    OldSignalHandlerINT(signo);
     exit(1);
 }
-static void MySignalHandlerQUIT ()
+static void MySignalHandlerQUIT (int signo)
 {
     fputs( "killing gap because of signal QUIT\n", stderr );
     KillGap();
-    OldSignalHandlerQUIT();
+    OldSignalHandlerQUIT(signo);
     exit(1);
 }
-static void MySignalHandlerILL ()
+static void MySignalHandlerILL (int signo)
 {
     fputs( "killing gap because of signal ILL\n", stderr );
     KillGap();
-    OldSignalHandlerILL();
+    OldSignalHandlerILL(signo);
     exit(1);
 }
-static void MySignalHandlerIOT ()
+static void MySignalHandlerIOT (int signo)
 {
     fputs( "killing gap because of signal IOT\n", stderr );
     KillGap();
-    OldSignalHandlerIOT();
+    OldSignalHandlerIOT(signo);
     exit(1);
 }
-static void MySignalHandlerBUS ()
+static void MySignalHandlerBUS (int signo)
 {
     fputs( "killing gap because of signal BUS\n", stderr );
     KillGap();
-    OldSignalHandlerBUS();
+    OldSignalHandlerBUS(signo);
     exit(1);
 }
 
-static void MySignalHandlerSEGV ()
+static void MySignalHandlerSEGV (int signo)
 {
     fputs( "killing gap because of signal SEGV\n", stderr );
     KillGap();
-    OldSignalHandlerSEGV();
+    OldSignalHandlerSEGV(signo);
     exit(1);
 }
 
 #else
 
-static void MySignalHandler ()
+static void MySignalHandler (int signo)
 {
     KillGap();
     exit(1);
@@ -927,9 +934,9 @@ static void MySignalHandler ()
 */
 static char * nargv[1024];
 
-static void ParseArgs ( argc, argv )
-    Int         argc;
-    char     ** argv;
+static void ParseArgs (
+    Int         argc,
+    char     ** argv)
 {
     Int		nargc;
     Int         i,  j;
@@ -1072,9 +1079,9 @@ fullusage:
 #include "bitmaps/exmark.bm"
 #include "bitmaps/menusym.bm"
 
-int main ( argc,  argv )
-    int         argc;
-    char     ** argv;
+int main (
+    int         argc,
+    char     ** argv)
 {
     String      color;
     String      colors;

--- a/src.x11/xgap.h
+++ b/src.x11/xgap.h
@@ -25,7 +25,7 @@
 typedef struct _menu_item
 {
   char 	  * label;
-  void      (*click)();
+  void      (*click)(struct _menu_item *);
   int       sensitive;
   Widget    entry;
 }


### PR DESCRIPTION
The Fedora project is currently building all packages with a GCC 15 prerelease.  This version of GCC changes the default C standard from C17 to C23.  One major change in C23 is that the declarations of the form `t f();` have changed semantics.  In C17 and earlier, that declares `f` as a function returning values of type `t` with an unspecified parameter list.  In C23, that declaration has the same meaning as `t f(void);`; i.e., it declares that `f` takes no parameters.  This change led to many compile-time errors when building xgap.

This PR adds explicit parameter lists as needed.  Also, the code had a mix of K&R and ANSI style function definitions.  This PR also converts the remaining K&R style definitions to ANSI style, thus avoiding a large number of warnings from GCC.  One side effect is that all signal handlers are now declared to take an `int` parameter, whether it is used or not.  In C23, one can add `[[maybe_unused]]` attributes, but that won't work for all extant compilers so I have left it out.

Two explicit declarations of `errno` were removed.  Those declarations are wrong.  On modern systems, `errno` is a thread-specific value, but the removed declarations lack the appropriate thread-specific attribute.

This work did turn up some cases where types were mismatched.  The last parameter of `GapSrcReadText` should have type `Int`, but was declared with type `unsigned long`.  The parameter of `UpdateXCMDS` has type `Boolean`, but was declared in `xcmds.h` to have type `Int`.